### PR TITLE
[CLOUD-205] Skip reloading consul when baking images for managed Cloud as certificates might not exist ie RonDB cluster

### DIFF
--- a/recipes/node_exporter.rb
+++ b/recipes/node_exporter.rb
@@ -128,6 +128,7 @@ end
 if service_discovery_enabled()
   consul_service "Registering node exporter with Consul" do
     service_definition "node-exporter-consul.hcl.erb"
+    reload_consul !is_managed_cloud()
     action :register
   end
 end 


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/CLOUD-205