### PR TITLE
[HWORKS-1061] Separate out of memory rules for ndbmtd nodes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -111,4 +111,4 @@ default['hopsmonitor']['prometheus']['kube-ca']          = ""
 
 # Configuration attributes for alerting rules
 default['prometheus']['rules']['all-hosts-available-mem-threshold']  = "10"
-default['prometheus']['rules']['ndbd-hosts-available-mem-threshold'] = "3"
+default['prometheus']['rules']['ndbd-hosts-available-mem-threshold'] = "1.5"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,6 +50,7 @@ default['node_exporter']['home']                  = "#{node['prometheus']['root_
 default['node_exporter']['base_dir']              = "#{node['prometheus']['root_dir']}/node_exporter"
 default['node_exporter']['filesystem']['regex']   = "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
 default['node_exporter']["text_metrics"]          = "#{default['node_exporter']['base_dir']}/text_metrics"
+default['node_exporter']['is-ndbmtd']             = "false"
 
 default['alertmanager']['port']                     = "9193"
 default['alertmanager']['clustered']                = "false"
@@ -107,3 +108,7 @@ default['cloud']['metrics']['port']                      = "9096"
 default['hopsmonitor']['prometheus']['kube-crt']         = ""
 default['hopsmonitor']['prometheus']['kube-key']         = ""
 default['hopsmonitor']['prometheus']['kube-ca']          = ""
+
+# Configuration attributes for alerting rules
+default['prometheus']['rules']['all-hosts-available-mem-threshold']  = "10"
+default['prometheus']['rules']['ndbd-hosts-available-mem-threshold'] = "3"

--- a/metadata.rb
+++ b/metadata.rb
@@ -193,5 +193,5 @@ attribute "prometheus/rules/all-hosts-available-mem-threshold",
           :type => "string"
 
 attribute "prometheus/rules/ndbd-hosts-available-mem-threshold",
-          :description => "Percentage of minimum available memory for ndbmtd only machines in the cluster, anything lower will fire an alert. Default: 3%",
+  :description => "Percentage of minimum available memory for ndbmtd only machines in the cluster, anything lower will fire an alert. Default: 1.5%",
           :type => "string"

--- a/metadata.rb
+++ b/metadata.rb
@@ -183,3 +183,15 @@ attribute "node_exporter/filesystem/regex",
 attribute "node_exporter/port",
           :description => "Port node_exporter will be listening to. Default: 9100",
           :type => "string"
+
+attribute "node_exporter/is-ndbmtd",
+          :description => "Flag to indicate that this node_exporter is installed in a machine where ndbmtd is installed to. It controls consul's tags. Normally it will auto-discovered except the cases where node_exporter is installed in a separate cluster definition. Default: false",
+          :type => "string"
+
+attribute "prometheus/rules/all-hosts-available-mem-threshold",
+          :description => "Percentage of minimum available memory for all but ndbmtd machines in the cluster, anything lower will fire an alert. Default: 10%",
+          :type => "string"
+
+attribute "prometheus/rules/ndbd-hosts-available-mem-threshold",
+          :description => "Percentage of minimum available memory for ndbmtd only machines in the cluster, anything lower will fire an alert. Default: 3%",
+          :type => "string"

--- a/recipes/node_exporter.rb
+++ b/recipes/node_exporter.rb
@@ -130,5 +130,8 @@ if service_discovery_enabled()
     service_definition "node-exporter-consul.hcl.erb"
     reload_consul !is_managed_cloud()
     action :register
+    template_variables ({
+      :is_ndbmtd => exists_local('ndb', 'ndbd') || node['node_exporter']['is-ndbmtd'].casecmp?('true')
+    })
   end
 end 

--- a/templates/default/node-exporter-consul.hcl.erb
+++ b/templates/default/node-exporter-consul.hcl.erb
@@ -2,7 +2,10 @@ service {
     id = "node_exporter/monitoring"
     name = "node_exporter"
     tags = [
-        "monitoring"
+        "monitoring",
+        <% if @is_ndbmtd -%>
+        "ndbmtd",
+        <% end -%>
     ]
     port = <%= node['node_exporter']['port'] %> 
     check = {

--- a/templates/default/prometheus.yml.erb
+++ b/templates/default/prometheus.yml.erb
@@ -51,6 +51,10 @@ scrape_configs:
         services: ['prometheus']
         tags: ['pushgateway']
 
+    relabel_configs:
+    - source_labels: ["__meta_consul_tags"]
+      target_label: tags
+
   - job_name: consul
 
     honor_timestamps: true
@@ -82,6 +86,8 @@ scrape_configs:
         regex:         '(.*):(<%= node['consul']['rpc_port'] %>)'
         target_label:  '__address__'
         replacement:   '${1}:<%= node['consul']['http_api_port'] %>'
+      - source_labels: ["__meta_consul_tags"]
+        target_label: tags
 
 
   - job_name: 'airflow'
@@ -100,6 +106,10 @@ scrape_configs:
 
         services: ['airflow']
         tags: ['monitoring']
+
+    relabel_configs:
+    - source_labels: ["__meta_consul_tags"]
+      target_label: tags
     
   - job_name: 'hadoop'
     scrape_interval:     10s
@@ -115,6 +125,10 @@ scrape_configs:
           insecure_skip_verify: true
 
         tags: ['monitoring']
+
+    relabel_configs:
+    - source_labels: ["__meta_consul_tags"]
+      target_label: tags
 
   - job_name: 'rdrs'
     scrape_interval:     10s
@@ -135,6 +149,10 @@ scrape_configs:
         services: ['rdrs']
         tags: ['monitoring']
 
+    relabel_configs:
+    - source_labels: ["__meta_consul_tags"]
+      target_label: tags
+
   - job_name: 'hopsworks'
 
     scrape_interval:     10s
@@ -154,6 +172,11 @@ scrape_configs:
 
         services: ['glassfish']
         tags: ['monitoring']
+
+    relabel_configs:
+    - source_labels: ["__meta_consul_tags"]
+      target_label: tags
+
   <% if node['install']['kubernetes'] == 'true' && !@managed_cloud -%>
   - job_name: 'knative-controller'
     scrape_interval: 3s

--- a/templates/default/rules/host.rules.yml.erb
+++ b/templates/default/rules/host.rules.yml.erb
@@ -2,13 +2,22 @@ groups:
 - name: host 
   rules:
   - alert: OutOfMemory
-    expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10
+    expr: node_memory_MemAvailable_bytes{tags !~ ".*ndbmtd.*"} / node_memory_MemTotal_bytes{tags !~ ".*ndbmtd.*"} * 100 < <%= node['prometheus']['rules']['all-hosts-available-mem-threshold'] %>
     for: 5m
     labels:
       type: system-alert
     annotations:
       summary: "Out of memory (instance {{ $labels.instance }})"
-      description: "Node memory is filling up (< 10% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+      description: "Node memory is filling up (< <%= node['prometheus']['rules']['all-hosts-available-mem-threshold'] %>% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+
+  - alert: RonDBDatanodesOutOfMemory
+    expr: node_memory_MemAvailable_bytes{tags != ".*ndbmtd.*"} / node_memory_MemTotal_bytes{tags != ".*ndbmtd.*"} * 100 < <%= node['prometheus']['rules']['ndbd-hosts-available-mem-threshold'] %>
+    for: 5m
+    labels:
+      type: system-alert
+    annotations:
+      summary: "RonDB datanode out of memory (instance {{ $labels.instance }})"
+      description: "Node memory is filling up (< <%= node['prometheus']['rules']['ndbd-hosts-available-mem-threshold'] %>% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
 
   - alert: OutOfInodes
     expr: node_filesystem_files_free / node_filesystem_files * 100 < 12

--- a/templates/default/rules/host.rules.yml.erb
+++ b/templates/default/rules/host.rules.yml.erb
@@ -11,7 +11,7 @@ groups:
       description: "Node memory is filling up (< <%= node['prometheus']['rules']['all-hosts-available-mem-threshold'] %>% left)\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
 
   - alert: RonDBDatanodesOutOfMemory
-    expr: node_memory_MemAvailable_bytes{tags != ".*ndbmtd.*"} / node_memory_MemTotal_bytes{tags != ".*ndbmtd.*"} * 100 < <%= node['prometheus']['rules']['ndbd-hosts-available-mem-threshold'] %>
+    expr: node_memory_MemAvailable_bytes{tags =~ ".*ndbmtd.*"} / node_memory_MemTotal_bytes{tags =~ ".*ndbmtd.*"} * 100 < <%= node['prometheus']['rules']['ndbd-hosts-available-mem-threshold'] %>
     for: 5m
     labels:
       type: system-alert


### PR DESCRIPTION
[HWORKS-1061] Attribute to explicitly mark a node_exporter as ndbmtd node

[HWORKS-1061]: https://hopsworks.atlassian.net/browse/HWORKS-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ